### PR TITLE
Added ping/pong heartbeat support to websockets.

### DIFF
--- a/internal/quiet/quiet.go
+++ b/internal/quiet/quiet.go
@@ -7,6 +7,14 @@ import "io"
 // trying to handle errors doesn't make a damn bit of difference.
 func Close(closer io.Closer) {
 	if closer != nil {
-		_ = closer.Close()
+		IgnoreError(closer.Close())
 	}
+}
+
+// IgnoreError is an explict way to indicate that you're performing some sort of action where
+// you really don't care about the error it can generate. Use this sparingly! Most errors
+// should be handled, but if you're trying to close a file right before exiting the program,
+// it may not be the end of the world to give a few less fucks about that error.
+func IgnoreError(_ error) {
+	// do nothing...
 }


### PR DESCRIPTION
Previously, the only way a websocket would close is if the application layer explicitly called `websocket.Close()` or if the client gracefully shut down its connection by sending an `OpClose` frame. There was no automatic detection of the case where the client's connection dropped due to crappy network, app crash, or the thousand other reasons the connection would just drop.

The `ConnectWebsocket()` supports 2 new options to support an automated ping/pong heartbeat to detect dropped connections: `PingInterval` and `IdleTimeout`. The first tells the server how often it should send a ping frame to the client in hopes of getting a pong response. The timeout option defines how long the websocket can go without receiving *any* sort of chatter from the client: no pongs, no messages, nothing. If the server doesn't hear anything after that amount of time, it closes the connection automatically.

This reduces leaked connections/memory and ensure that the `OnClose` lifecycle handler is properly run in cases where the client just disappears.