### PR TITLE
Generated JS client JSDoc now includes namespace in type names.

### DIFF
--- a/generate/templates/client.js.tmpl
+++ b/generate/templates/client.js.tmpl
@@ -438,9 +438,14 @@ class GatewayError {
  property type is our best-guess, but the "|*" makes sure that your editor's tooling doesn't
  pitch a fit if you know that your JS code uses different type formats.
 */}}
+{{ $packageName := .OutputPackage.Name }}
+/**
+ * @namespace {{ $packageName }}
+ */
 {{ range .Types.NonBasicTypes }}
 /**
- * @typedef { {{ . | JSTypedefType }} } {{ .Name | JoinPackageName | NoPointer }}{{ range .Fields }}
+ * @typedef { {{ . | JSTypedefType }} } {{ $packageName }}~{{ .Name | JoinPackageName | NoPointer }}
+ * {{ range .Fields }}
  * @property { {{ .Type | JSPropertyType }}|* } [{{ .Binding.Name }}]{{ end }}
 */
 {{- end }}

--- a/makefile
+++ b/makefile
@@ -15,13 +15,14 @@ endif
 #
 build:
 	@ \
+	mkdir -p out && \
 	go build -o out/frodo main.go
 
 install: build
 	@ \
- 	echo "Overwriting go-installed version..." && \
  	mkdir -p $$GOPATH/bin && \
- 	cp out/frodo $$GOPATH/bin/frodo
+ 	cp out/frodo $$GOPATH/bin/frodo && \
+ 	echo "Overwriting $$GOPATH/bin/frodo"
 
 #
 # Runs the all of the test suites for the entire Frodo module.
@@ -52,3 +53,10 @@ generate: build
 	go generate ./internal/testext/... && \
 	mv ./internal/testext/gen/*.client.js ./generate/testdata/js/ && \
 	mv ./internal/testext/gen/*.client.dart ./generate/testdata/dart/
+
+#
+# Blows away the build directory so the next build is absolutely from scratch.
+#
+clean:
+	@ \
+ 	rm -rf out


### PR DESCRIPTION
It's not unheard of to have multiple types with the same name in different packages/services (e.g. `user.Option` and `project.Option`). When building JS clients, the `@typedef` JSDoc for both types would just be `Option` which means your IDE could get confused as to which version you meant if you specified `@type {Option}`.

Now, we use the Go package name as a namespace for the types, so in the previous example, the typedefs now look like this:

```
@typedef {object} user~Option
@typedef {object} project~Option
```

And when annotating types in your code you can now be more specific:

```
/** @type {project~Option} */
const myOption = foo();
```