### PR TITLE
Better package~type JSDoc generation.

### DIFF
--- a/generate/templates/client.js.tmpl
+++ b/generate/templates/client.js.tmpl
@@ -7,6 +7,10 @@
 /* global fetch,module,window,WebSocket */
 'use strict';
 
+{{ $outputPackage := .OutputPackage }}
+{{ $packageName := .OutputPackage.Name }}
+{{ $types := .Types }}
+
 /**
  * Exposes all of the standard operations for the remote {{ .Service.Name }} service. These RPC calls
  * will be sent over http(s) to the backend service instances. {{ range .Service.Documentation }}
@@ -43,18 +47,18 @@ class {{ .Service.Name }}Client {
     /**{{ range $doc := .Documentation }}
      * {{ . }} {{ end }}
      *
-     * @param { {{ .Request.Name }} } serviceRequest The input parameters
+     * @param { {{ $packageName }}~{{ .Request.Name }} } serviceRequest The input parameters
      * @param {object} [options]
      * @param { string } [options.authorization] The HTTP Authorization header value to include
      *     in the request. This will override any authorization you might have applied when
      *     constructing this client. Use this in multi-tenant situations where multiple users
      *     might utilize this service.
     {{- if .Response.Implements.ContentGetter }}
-     * @returns {Promise<{{ .Response.Name }}> | StreamedResponse } The raw stream data returned by the server.
+     * @returns {Promise<{{ $packageName }}~{{ .Response.Name }}> | StreamedResponse } The raw stream data returned by the server.
     {{- else }} {{- if and $apiRoute $apiRoute.RouteType.Websocket }}
      * @returns {Promise< WebSocket > } The socket connection we're opening w/ the server.
     {{- else }}
-        * @returns {Promise<{{ .Response.Name }}> } The JSON-encoded return value of the operation.
+        * @returns {Promise<{{ $packageName }}~{{ .Response.Name }}> } The JSON-encoded return value of the operation.
     {{- end }}{{- end }}
      */
     async {{ .Name }}(serviceRequest, {authorization} = {}) {
@@ -438,15 +442,11 @@ class GatewayError {
  property type is our best-guess, but the "|*" makes sure that your editor's tooling doesn't
  pitch a fit if you know that your JS code uses different type formats.
 */}}
-{{ $packageName := .OutputPackage.Name }}
-/**
- * @namespace {{ $packageName }}
- */
 {{ range .Types.NonBasicTypes }}
 /**
- * @typedef { {{ . | JSTypedefType }} } {{ $packageName }}~{{ .Name | JoinPackageName | NoPointer }}
+ * @typedef { {{ JSTypedefType . $outputPackage }} } {{ JSTypedefName . $outputPackage }}
  * {{ range .Fields }}
- * @property { {{ .Type | JSPropertyType }}|* } [{{ .Binding.Name }}]{{ end }}
+ * @property { {{ JSPropertyType .Type $outputPackage }}|* } [{{ .Binding.Name }}]{{ end }}
 */
 {{- end }}
 
@@ -465,5 +465,10 @@ class GatewayError {
  * @property { number } [End]
  * @property { number } [Size]
  */
+
+/** @namespace {{ $packageName }} */
+{{ range .Types.ExternalPackageNames }}
+/** @namespace {{ . }} */
+{{ end }}
 
 export { {{ .Service.Name }}Client };

--- a/internal/naming/naming.go
+++ b/internal/naming/naming.go
@@ -31,7 +31,13 @@ func NoSlice(ident string) string {
 // JoinPackageName converts a package-qualified type such as "fmt.Stringer" into a single "safe" identifier
 // such as "fmtStringer". This is useful when converting types to languages with different naming semantics.
 func JoinPackageName(ident string) string {
-	return strings.ReplaceAll(ident, ".", "")
+	return JoinPackageNameWith(ident, "")
+}
+
+// JoinPackageNameWith converts a package-qualified type such as "fmt.Stringer" into a single "safe" identifier
+// such as "fmt_Stringer". This is useful when converting types to languages with different naming semantics.
+func JoinPackageNameWith(ident string, sep string) string {
+	return strings.ReplaceAll(ident, ".", sep)
 }
 
 // NoImport strips off the prefix before "/" in your type identifier (e.g. "github.com/foo/bar/Baz" -> "Baz")

--- a/internal/slices/slices.go
+++ b/internal/slices/slices.go
@@ -38,3 +38,13 @@ func Contains[T comparable](slice []T, value T) bool {
 	}
 	return false
 }
+
+// AppendUnique appends the value to the slice only if the slice does not contain an equivalent value.
+func AppendUnique[T comparable](slice []T, value T) []T {
+	for _, sliceValue := range slice {
+		if sliceValue == value {
+			return slice
+		}
+	}
+	return append(slice, value)
+}

--- a/parser/context.go
+++ b/parser/context.go
@@ -14,6 +14,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/bridgekit-io/frodo/internal/naming"
+	"github.com/bridgekit-io/frodo/internal/slices"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -763,6 +764,19 @@ func (reg TypeRegistry) NonBasicTypes() []*TypeDeclaration {
 		results = append(results, t)
 	}
 	return results
+}
+
+// ExternalPackageNames returns a set of any package names used by types in this service that are not defined in the service
+// package. These could be standard library package (e.g. time.Time would include "time") or some other core package in your
+// application (e.g. datastore.ID would include "datastore").
+func (reg TypeRegistry) ExternalPackageNames() []string {
+	packageNames := make([]string, 0, 8)
+	for _, t := range reg {
+		if packageName, _, ok := strings.Cut(t.Name, "."); ok {
+			packageNames = slices.AppendUnique(packageNames, packageName)
+		}
+	}
+	return packageNames
 }
 
 func (reg TypeRegistry) key(t types.Type, name string) string {

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -668,6 +668,9 @@ func ParseBindingOptions(ctx *Context, field *FieldDeclaration, fieldVar *types.
 	// We don't care about 'omitempty' or anything other than the remapped name. The
 	// runtime binder cares, but not the syntax parser.
 	switch name := strings.Split(tag, ",")[0]; name {
+	case "":
+		// It looked like "json:,omitempty". There are options, but no name remapping, so stick with the varName() from above.
+		return options
 	case "-":
 		options.Omit = true
 		return options


### PR DESCRIPTION
Deals with 2 nagging issues with JS client generation:

## Package Names and Namespaces

It's possible that when building your app, you might have multiple Go structs with the same name, just in different packages:

```
// In identity_service.go
type Token struct { }
// In integration_service.go
type Token struct { }
```

Before, the JS client would generate the same JSDoc type for both:.

```
/**
 * @typedef {object} Token
 */
```

Now in your frontend, if you defined a variable for your Token, it would be ambiguous which one you meant:

```
/** @type Token */
const token = fetchToken();
```

Now, Frodo includes the Go package name as a namespace for the types, so the resulting JSDoc would look like this, and below, your frontend could reference them using their fully qualified version:

```
// In identity_service.gen.client.js
/** @typedef {object} identity~Token */
// In integreation_service.gen.client.js
/** @typedef {object} integration~Token */

// In your frontend

/** @type {identity~Token} */
const token = fetchToken();
```

Now your code knows which one you're talking about.

## JSDoc name was empty for `json:,omitempty` fields

If you included that exact Go JSON tag on a struct field, the JSDoc for that field would be empty.

```
// In foo_service.go
type Foo struct {
    Bar string `json:,omitempty`
}

// In foo_service.gen.client.js
/**
 * @type {object} foo~Foo
 * @property {string} []   <-- name was missing
 */
```

The code was blindly assuming that if you had a JSON tag, there was a rename in there. Now it just uses the struct field name if the remapping value is blank.