### PR TITLE
Properly propagate cancel context when starting gateways.

### DIFF
--- a/services/server.go
+++ b/services/server.go
@@ -248,7 +248,7 @@ func (server *Server) Invoke(ctx context.Context, serviceName string, methodName
 func (server *Server) Run(ctx context.Context) error {
 	server.shutdownComplete.Add(1)
 
-	errs, _ := fail.NewGroup(ctx)
+	errs, ctx := fail.NewGroup(ctx)
 	for _, gw := range server.gateways {
 		server.logger.Info("[frodo] starting gateway: " + gw.Type().String())
 		errs.Go(func() error { return gw.Listen(ctx) })


### PR DESCRIPTION
Fixed #31 

When creating the error group that captures failures for all launched gateways, I was not propagating the cancel context it generates. So when one gateway start failed, the cancellation never propagated to the other gateways. Not it does and the attempt to `server.Run()` exits as expected, letting me shut down the program appropriately.